### PR TITLE
Use upper case for variable name, and lower case for accessor

### DIFF
--- a/examples/print.rs
+++ b/examples/print.rs
@@ -62,16 +62,16 @@ impl Value for Color {
 fn main() {
     let args = gflags::parse();
 
-    if help.FLAG {
+    if HELP.flag {
         print_help_and_exit();
     }
 
-    println!("big_menu = {}", big_menu.FLAG);
-    println!("language = {}", language.FLAG);
-    if file.is_present() {
-        println!("file = {}", file.FLAG.display());
+    println!("big_menu = {}", BIG_MENU.flag);
+    println!("language = {}", LANGUAGE.flag);
+    if FILE.is_present() {
+        println!("file = {}", FILE.flag.display());
     }
-    println!("color = {:?}", color.FLAG);
+    println!("color = {:?}", COLOR.flag);
     println!("args = {:?}", args);
 }
 

--- a/impl/src/name.rs
+++ b/impl/src/name.rs
@@ -32,7 +32,7 @@ impl Short {
 impl Long {
     pub fn to_ident(&self) -> Ident {
         let span = self.segments[0].span();
-        let symbol = self.to_string().replace('-', "_");
+        let symbol = self.to_string().replace('-', "_").to_uppercase();
         Ident::new(&symbol, span)
     }
 }

--- a/src/help.rs
+++ b/src/help.rs
@@ -19,7 +19,7 @@ use crate::registry::Flag;
 ///
 /// fn main() {
 ///     gflags::parse();
-///     if help.FLAG {
+///     if HELP.flag {
 ///         gflags::print_help_and_exit(0);
 ///     }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //! [`gflags::parse()`]: fn.parse.html
 //!
 //! After `gflags::parse()` has been called, the value of each flag is available
-//! in the `.FLAG` field of the flag's long name.
+//! in the `.flag` field of the flag's long name.
 //!
 //! ```
 //! gflags::define! {
@@ -97,7 +97,7 @@
 //! fn main() {
 //!     let args = gflags::parse();
 //!
-//!     if print_args.FLAG {
+//!     if PRINT_ARGS.flag {
 //!         println!("args = {:?}", args);
 //!     }
 //! }
@@ -110,7 +110,7 @@
 //! Additionally every flag provides a method `.is_present()` to query whether
 //! that flag was provided on the command line. When using flags for which a
 //! default value is not provided, be sure to check `.is_present()` because
-//! accessing `.FLAG` when not present will cause a panic. Note also that flags
+//! accessing `.flag` when not present will cause a panic. Note also that flags
 //! without a default value must specify their data type, as below.
 //!
 //! ```
@@ -124,8 +124,8 @@
 //! fn main() {
 //!     let patterns = gflags::parse();
 //!
-//!     if file.is_present() {
-//!         let path = file.FLAG;
+//!     if FILE.is_present() {
+//!         let path = FILE.flag;
 //!         println!("searching for patterns from file: {}", path.display());
 //!     } else {
 //!         println!("searching for patterns given on command line: {:?}", patterns);
@@ -148,7 +148,7 @@
 //!
 //! fn main() {
 //!     gflags::parse();
-//!     if help.FLAG {
+//!     if HELP.flag {
 //!         gflags::print_help_and_exit(0);
 //!     }
 //!

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -11,7 +11,7 @@ use crate::token::{Token, Tokenizer};
 ///
 /// This function must be called before accessing the values of any flags. After
 /// this function has been called, the values of flags are available in the
-/// `.FLAG` field of each flag.
+/// `.flag` field of each flag.
 ///
 /// The return vector contains everything on the command line which is not a
 /// flag. These are sometimes called positional arguments.
@@ -31,7 +31,7 @@ use crate::token::{Token, Tokenizer};
 /// fn main() {
 ///     let args = gflags::parse();
 ///
-///     if print_args.FLAG {
+///     if PRINT_ARGS.flag {
 ///         println!("args = {:?}", args);
 ///     }
 /// }

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,7 +12,7 @@ use crate::atomic::StaticAtomicPtr;
 /// state of the flag can be accessed.
 ///
 /// After [`gflags::parse()`] has been called, the value of a flag is available
-/// through its `.FLAG` field which is of type `T`.
+/// through its `.flag` field which is of type `T`.
 ///
 /// [`gflags::define!`]: macro.define.html
 /// [`gflags::parse()`]: fn.parse.html
@@ -30,8 +30,8 @@ use crate::atomic::StaticAtomicPtr;
 /// fn main() {
 ///     let patterns = gflags::parse();
 ///
-///     if file.is_present() {
-///         let path = file.FLAG;
+///     if FILE.is_present() {
+///         let path = FILE.flag;
 ///         println!("searching for patterns from file: {}", path.display());
 ///     } else {
 ///         println!("searching for patterns given on command line: {:?}", patterns);
@@ -47,11 +47,11 @@ impl<T: 'static> Flag<T> {
     /// Whether this flag was provided on the command line.
     ///
     /// When using flags for which a default value is not provided, be sure to
-    /// check `.is_present()` because accessing `.FLAG` when not present will
+    /// check `.is_present()` because accessing `.flag` when not present will
     /// cause a panic.
     ///
     /// When a flag has a default value and is not passed on the command line,
-    /// `is_present()` will be false and `.FLAG` will refer to the default
+    /// `is_present()` will be false and `.flag` will refer to the default
     /// value.
     pub fn is_present(&self) -> bool {
         self.present.load(Ordering::SeqCst)
@@ -63,7 +63,7 @@ impl<T: 'static> Flag<T> {
 #[repr(transparent)]
 pub struct Accessor<T> {
     /// Value of the flag.
-    pub FLAG: T,
+    pub flag: T,
 }
 
 impl<T: 'static> Flag<T> {


### PR DESCRIPTION
Still down for `FLAGS_help.value` if this doesn't look right to you.