### PR TITLE
More convenient parser for programs that only support UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Flags of a type other than bool may have an optional value-placeholder like
 ## Accessing flags
 
 Somewhere early in your application, call [`gflags::parse()`] to parse the
-command line. This call returns a `Vec<OsString>` containing everything on the
+command line. This call returns a `Vec<&str>` containing everything on the
 command line which is not a flag (these are sometimes known as positional
 arguments) in a vector.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,9 @@
 //! # Accessing flags
 //!
 //! Somewhere early in your application, call [`gflags::parse()`] to parse the
-//! command line. This call returns a `Vec<OsString>` containing everything on
-//! the command line which is not a flag (these are sometimes known as
-//! positional arguments) in a vector.
+//! command line. This call returns a `Vec<&str>` containing everything on the
+//! command line which is not a flag (these are sometimes known as positional
+//! arguments) in a vector.
 //!
 //! [`gflags::parse()`]: fn.parse.html
 //!
@@ -233,7 +233,7 @@ mod value;
 pub mod custom;
 
 pub use crate::help::print_help_and_exit;
-pub use crate::parse::parse;
+pub use crate::parse::{parse, parse_os};
 pub use crate::state::Flag;
 
 // Not public API.


### PR DESCRIPTION
This mirrors `std::env::args` / `args_os` and `std::env::var` / `var_os`.