### PR TITLE
Parse `--flag=value` syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ gflags-impl = { version = "=0.3.3", path = "impl" }
 inventory = "0.1.1"
 ref-cast = "1.0"
 
+[dev-dependencies]
+assert_cmd = "1"
+predicates = "1"
+
 [workspace]
 members = ["impl"]
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -106,22 +106,22 @@ pub fn parse_os() -> Vec<&'static OsStr> {
                     process::exit(1);
                 }
             },
-            Token::LongEq(name) => {
+            Token::LongEq(name, arg) => {
                 if let Some(flag) = longs.get(name) {
-                    if !flag.parser.is_bool() {
-                        let name = Name::long(flag.name);
-                        flag.parser.parse(name, &mut tokens);
-                        continue;
+                    if flag.parser.is_bool() {
+                        eprintln!("Unexpected argument {:?} for flag: --{}={}", arg, name, arg);
+                        process::exit(1);
                     }
+
+                    let name = Name::long(flag.name);
+
+                    // Prepare an iterator and tokenizer for just this arg, then
+                    // parse the arg for the flag
+                    let arg = vec![OsStr::new(arg)];
+                    let mut tokens = Tokenizer::new_with_iterator(arg.into_iter());
+
+                    flag.parser.parse(name, &mut tokens);
                 }
-
-                let arg = match tokens.next_arg() {
-                    Some(arg) => arg,
-                    None => OsStr::new(""),
-                };
-
-                eprintln!("Unexpected argument {:?} for flag: --{}", arg, name);
-                process::exit(1);
             }
             Token::Arg(arg) => args.push(arg),
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -121,6 +121,9 @@ pub fn parse_os() -> Vec<&'static OsStr> {
                     let mut tokens = Tokenizer::new_with_iterator(arg.into_iter());
 
                     flag.parser.parse(name, &mut tokens);
+                } else {
+                    eprintln!("Unrecognized flag: --{}", name);
+                    process::exit(1);
                 }
             }
             Token::Arg(arg) => args.push(arg),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -106,6 +106,23 @@ pub fn parse_os() -> Vec<&'static OsStr> {
                     process::exit(1);
                 }
             },
+            Token::LongEq(name) => {
+                if let Some(flag) = longs.get(name) {
+                    if !flag.parser.is_bool() {
+                        let name = Name::long(flag.name);
+                        flag.parser.parse(name, &mut tokens);
+                        continue;
+                    }
+                }
+
+                let arg = match tokens.next_arg() {
+                    Some(arg) => arg,
+                    None => OsStr::new(""),
+                };
+
+                eprintln!("Unexpected argument {:?} for flag: --{}", arg, name);
+                process::exit(1);
+            }
             Token::Arg(arg) => args.push(arg),
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -57,7 +57,7 @@ impl Tokenizer {
             return match string.find('=') {
                 // "--foo bar" case
                 None => Some(Token::Long(&string[2..])),
-                // "--foo-bar" case, save value in self.pending
+                // "--foo=bar" case, save value in self.pending
                 Some(i) => {
                     self.pending = &string[i + 1..];
                     self.pending_index = 0;

--- a/src/token.rs
+++ b/src/token.rs
@@ -197,10 +197,9 @@ mod tests {
         assert_eq!(tokenizer.next().unwrap(), Token::Short('a'));
         assert_eq!(tokenizer.next().unwrap(), Token::Long("foo"));
         assert_eq!(tokenizer.next_arg().unwrap(), "bar");
-        assert_eq!(tokenizer.next_arg().unwrap(), "--");
         // After the '--' everything should be interpreted literally
-        assert_eq!(tokenizer.next_arg().unwrap(), "--baz");
-        assert_eq!(tokenizer.next_arg().unwrap(), "-b");
-        assert_eq!(tokenizer.next_arg().unwrap(), "hello");
+        assert_eq!(tokenizer.next().unwrap(), Token::Arg(OsStr::new("--baz")));
+        assert_eq!(tokenizer.next().unwrap(), Token::Arg(OsStr::new("-b")));
+        assert_eq!(tokenizer.next().unwrap(), Token::Arg(OsStr::new("hello")));
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -11,6 +11,7 @@ pub struct Tokenizer {
 pub enum Token {
     Short(char),
     Long(&'static str),
+    LongEq(&'static str),
     Arg(&'static OsStr),
 }
 
@@ -61,7 +62,7 @@ impl Tokenizer {
                 Some(i) => {
                     self.pending = &string[i + 1..];
                     self.pending_index = 0;
-                    Some(Token::Long(&string[2..i]))
+                    Some(Token::LongEq(&string[2..i]))
                 }
             };
         }
@@ -184,7 +185,7 @@ mod tests {
     fn one_long_flag_one_arg_equals() {
         let args = args_as_ref(&["binary", "--foo=bar"]);
         let mut tokenizer = Tokenizer::new_with_iterator(args.into_iter());
-        assert_eq!(tokenizer.next().unwrap(), Token::Long("foo"));
+        assert_eq!(tokenizer.next().unwrap(), Token::LongEq("foo"));
         assert_eq!(tokenizer.next_arg().unwrap(), "bar");
     }
 

--- a/tests/print.rs
+++ b/tests/print.rs
@@ -1,0 +1,98 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::error::Error;
+use std::ffi;
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+#[test]
+fn no_flags() -> Result<()> {
+    let mut cmd = Command::cargo_bin("examples/print")?;
+    cmd.assert().success();
+    Ok(())
+}
+
+/// Helper function to test errors when passing invalid arguments. Runs the
+/// binary, passing `args`, expecting a failure that contains `msg`.
+pub fn test_args_failure<I, S>(args: I, msg: &str) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<ffi::OsStr>,
+{
+    let mut cmd = Command::cargo_bin("examples/print")?;
+    cmd.args(args);
+    cmd.assert().failure().stderr(predicate::str::contains(msg));
+    Ok(())
+}
+
+/// Helper function to test successes when passing valid arguments. Runs the
+/// binary, passing `args`, expecting success that contains `msg`.
+pub fn test_args_success<I, S>(args: I, msg: &str) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<ffi::OsStr>,
+{
+    let mut cmd = Command::cargo_bin("examples/print")?;
+    cmd.args(args);
+    cmd.assert().success().stdout(predicate::str::contains(msg));
+    Ok(())
+}
+
+// Failure cases
+
+#[test]
+fn unrecognized_short_flag() -> Result<()> {
+    test_args_failure(&["-x"], "Unrecognized flag: -x")
+}
+
+#[test]
+fn unrecognized_long_flag_no_arg() -> Result<()> {
+    test_args_failure(&["--foo"], "Unrecognized flag: --foo")
+}
+
+#[test]
+fn unrecognized_long_flag_with_arg() -> Result<()> {
+    test_args_failure(&["--foo", "bar"], "Unrecognized flag: --foo")
+}
+
+#[test]
+fn unrecognized_long_flag_equals_with_arg() -> Result<()> {
+    test_args_failure(&["--foo=bar"], "Unrecognized flag: --foo")
+}
+
+#[test]
+fn unrecognized_long_flag_equals() -> Result<()> {
+    test_args_failure(&["--foo="], "Unrecognized flag: --foo")
+}
+
+// Success cases
+
+#[test]
+fn short_language_flag() -> Result<()> {
+    test_args_success(&["-l", "french"], "language = french\n")
+}
+
+#[test]
+fn short_language_flag_cuddled() -> Result<()> {
+    test_args_success(&["-lfrench"], "language = french\n")
+}
+
+#[test]
+fn long_language_flag() -> Result<()> {
+    test_args_success(&["--language", "french"], "language = french\n")
+}
+
+#[test]
+fn long_language_flag_equals() -> Result<()> {
+    test_args_success(&["--language=french"], "language = french\n")
+}
+
+#[test]
+fn no_prefix_on_long_args() -> Result<()> {
+    test_args_success(&["--nobig_menu"], "big_menu = false")
+}
+
+#[test]
+fn args_are_passed_through() -> Result<()> {
+    test_args_success(&["foo"], "args = [\"foo\"]")
+}


### PR DESCRIPTION
Update the tokenizer to support parsing`--flag=value` syntax.

To make sure this works, introduce unit tests for the tokenizer.

Closes #2 