### PR TITLE
Implements issue #16 - count flag repetitions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*~
+*.swp
+
 /target
 **/*.rs.bk
 Cargo.lock

--- a/examples/print.rs
+++ b/examples/print.rs
@@ -28,11 +28,17 @@ gflags::define! {
 }
 
 gflags::define! {
+    /// Be verbose. Increase verbosity level by repeating the flag; `-vv` for very verbose.
+    -v, --verbose = false
+}
+
+gflags::define! {
     /// Search for patterns from the given file, with one pattern per line.
     -f, --file: &Path
 }
 
 gflags::define! {
+    /// When to use color. Can be one of never, always, auto.
     --color <WHEN>: Color = Color::Auto
 }
 
@@ -71,6 +77,9 @@ fn main() {
         println!("file = {}", FILE.flag.display());
     }
     println!("color = {:?}", COLOR.flag);
+    println!("verbose = {}", VERBOSE.flag);
+    println!("is verbose? = {}", VERBOSE.is_present());
+    println!("verbose count = {}", VERBOSE.repeat_count());
     println!("args = {:?}", args);
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 use crate::atomic::StaticAtomicPtr;
 use ref_cast::RefCast;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 
 /// The state associated with a single flag.
 ///
@@ -38,7 +38,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// ```
 pub struct Flag<T> {
     atomic: StaticAtomicPtr<T>,
-    present: AtomicBool,
+    present: AtomicU8,
+    //present: AtomicBool,
 }
 
 impl<T: 'static> Flag<T> {
@@ -52,6 +53,18 @@ impl<T: 'static> Flag<T> {
     /// `is_present()` will be false and `.flag` will refer to the default
     /// value.
     pub fn is_present(&self) -> bool {
+        self.present.load(Ordering::SeqCst) != 0
+    }
+
+    /// Count number of times an option is repeated on the command line.
+    ///
+    /// Useful to display verbosity or debug level by repeating a boolean flag
+    /// several times. For example, `-vv` for "very verbose" (repeat count 2)
+    /// or `-ddd` for debug level 3.
+    ///
+    /// The count wraps around to zero if an option is repeated on the
+    /// command line 256 times.
+    pub fn repeat_count(&self) -> u8 {
         self.present.load(Ordering::SeqCst)
     }
 }
@@ -69,7 +82,8 @@ impl<T: 'static> Flag<T> {
     pub const fn new(default: &'static T) -> Self {
         Flag {
             atomic: StaticAtomicPtr::new(default),
-            present: AtomicBool::new(false),
+            present: AtomicU8::new(0),
+            //present: AtomicBool::new(false),
         }
     }
 
@@ -78,14 +92,16 @@ impl<T: 'static> Flag<T> {
     pub const fn null() -> Self {
         Flag {
             atomic: StaticAtomicPtr::null(),
-            present: AtomicBool::new(false),
+            present: AtomicU8::new(0),
+            //present: AtomicBool::new(false),
         }
     }
 
     pub(crate) fn set(&self, value: T) {
         let ptr = Box::leak(Box::new(value));
         self.atomic.store(ptr);
-        self.present.store(true, Ordering::SeqCst);
+        self.present.fetch_add(1, Ordering::SeqCst);
+        //self.present.store(true, Ordering::SeqCst);
     }
 }
 
@@ -93,7 +109,8 @@ impl Flag<bool> {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub(crate) fn set_bool(&self, value: &'static bool) {
         self.atomic.store(value);
-        self.present.store(true, Ordering::SeqCst);
+        self.present.fetch_add(1, Ordering::SeqCst);
+        //self.present.store(true, Ordering::SeqCst);
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 use crate::atomic::StaticAtomicPtr;
 use ref_cast::RefCast;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 /// The state associated with a single flag.
 ///
@@ -38,7 +38,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 /// ```
 pub struct Flag<T> {
     atomic: StaticAtomicPtr<T>,
-    present: AtomicU8,
+    present: AtomicU32,
 }
 
 impl<T: 'static> Flag<T> {
@@ -60,10 +60,7 @@ impl<T: 'static> Flag<T> {
     /// Useful to display verbosity or debug level by repeating a boolean flag
     /// several times. For example, `-vv` for "very verbose" (repeat count 2)
     /// or `-ddd` for debug level 3.
-    ///
-    /// The count wraps around to zero if an option is repeated on the
-    /// command line 256 times.
-    pub fn repeat_count(&self) -> u8 {
+    pub fn repeat_count(&self) -> u32 {
         self.present.load(Ordering::SeqCst)
     }
 }
@@ -81,7 +78,7 @@ impl<T: 'static> Flag<T> {
     pub const fn new(default: &'static T) -> Self {
         Flag {
             atomic: StaticAtomicPtr::new(default),
-            present: AtomicU8::new(0),
+            present: AtomicU32::new(0),
         }
     }
 
@@ -90,7 +87,7 @@ impl<T: 'static> Flag<T> {
     pub const fn null() -> Self {
         Flag {
             atomic: StaticAtomicPtr::null(),
-            present: AtomicU8::new(0),
+            present: AtomicU32::new(0),
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -39,7 +39,6 @@ use std::sync::atomic::{AtomicU8, Ordering};
 pub struct Flag<T> {
     atomic: StaticAtomicPtr<T>,
     present: AtomicU8,
-    //present: AtomicBool,
 }
 
 impl<T: 'static> Flag<T> {
@@ -83,7 +82,6 @@ impl<T: 'static> Flag<T> {
         Flag {
             atomic: StaticAtomicPtr::new(default),
             present: AtomicU8::new(0),
-            //present: AtomicBool::new(false),
         }
     }
 
@@ -93,7 +91,6 @@ impl<T: 'static> Flag<T> {
         Flag {
             atomic: StaticAtomicPtr::null(),
             present: AtomicU8::new(0),
-            //present: AtomicBool::new(false),
         }
     }
 
@@ -101,7 +98,6 @@ impl<T: 'static> Flag<T> {
         let ptr = Box::leak(Box::new(value));
         self.atomic.store(ptr);
         self.present.fetch_add(1, Ordering::SeqCst);
-        //self.present.store(true, Ordering::SeqCst);
     }
 }
 
@@ -110,7 +106,6 @@ impl Flag<bool> {
     pub(crate) fn set_bool(&self, value: &'static bool) {
         self.atomic.store(value);
         self.present.fetch_add(1, Ordering::SeqCst);
-        //self.present.store(true, Ordering::SeqCst);
     }
 }
 

--- a/tests/print.rs
+++ b/tests/print.rs
@@ -72,6 +72,27 @@ fn short_language_flag_cuddled() {
 }
 
 #[test]
+fn short_flag_repeat() {
+    test_args_success(&[""], 
+    "verbose = false\nis verbose? = false\nverbose count = 0\n");
+
+    test_args_success(&["-v", "-v"], 
+    "verbose = true\nis verbose? = true\nverbose count = 2\n");
+}
+
+#[test]
+fn short_flag_repeat_packed() {
+    test_args_success(&["-vv"], 
+    "verbose = true\nis verbose? = true\nverbose count = 2\n");
+}
+
+#[test]
+fn long_flag_repeat() {
+    test_args_success(&["--verbose", "--verbose"], 
+    "verbose = true\nis verbose? = true\nverbose count = 2\n");
+}
+
+#[test]
 fn long_language_flag() {
     test_args_success(&["--language", "french"], "language = french\n");
 }


### PR DESCRIPTION
Flag::repeat_count - number of times an option is repeated on the command line.
Useful with repeated boolean flags like `-vv` for "very verbose" (count of 2)
or `-ddd` for the debug_level 3.

[x] Add tests for short and long repeated flags.
[x] Add documentation for fn `repeat_count`.

Closes #16.